### PR TITLE
Fix bugs

### DIFF
--- a/bot/jujutsu.go
+++ b/bot/jujutsu.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"Pix4Devs/CursedSpirits/globals"
@@ -22,14 +21,11 @@ type (
 		StopAt      int
 		Client      *http.Client
 		Protocol    string
-		Mx          sync.Mutex
 	}
 )
 
 func (ctx *FloodCtx) Jujutsu(proxy string) {
 	if int(time.Now().Unix()) >= ctx.StopAt {
-		ctx.Mx.Lock()
-
 		fmt.Println("Forced STOP due to flood duration exceeded given time")
 		os.Exit(0)
 	}
@@ -65,9 +61,6 @@ func (ctx *FloodCtx) Jujutsu(proxy string) {
 }
 
 func (ctx *FloodCtx) cfg_tp(proxy string) {
-	ctx.Mx.Lock()
-	defer ctx.Mx.Unlock()
-
 	ctx.Client.Transport = &http.Transport{
 		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 		Dial:              socks.Dial(fmt.Sprintf("%s://%s?timeout=10s", ctx.Protocol, proxy)),

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func main() {
 	// setup one listener for signal interruption like ctrl+c
 	go func(){
 		<-exit
+		fancy.PrintCtx("Called exit signal, exiting soon.")
 		os.Exit(0)
 	}()
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"Pix4Devs/CursedSpirits/bot"
@@ -100,7 +101,7 @@ func main() {
 
 
 	exit := make(chan os.Signal) 
-	signal.Notify(exit, os.Interrupt)
+	signal.Notify(exit, os.Interrupt, syscall.SIGINT)
 
 	// setup one listener for signal interruption like ctrl+c
 	go func(){

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -96,6 +97,16 @@ func main() {
 
 	fancy.PrintCtx("Started flood against '" + *TARGET + "'")
 	fmt.Println()
+
+
+	exit := make(chan os.Signal) 
+	signal.Notify(exit, os.Interrupt)
+
+	// setup one listener for signal interruption like ctrl+c
+	go func(){
+		<-exit
+		os.Exit(0)
+	}()
 
 	for {
 		go func() {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"Pix4Devs/CursedSpirits/bot"
@@ -98,7 +97,6 @@ func main() {
 			Timeout: time.Duration(time.Second * 20),
 		},
 		Protocol: *PROXY_TYPE,
-		Mx:       sync.Mutex{},
 	}
 
 	fancy.PrintCtx("Started flood against '" + *TARGET + "'")
@@ -106,15 +104,6 @@ func main() {
 
 	for {
 		go func() {
-			// ==================
-			// reset tcp cache state
-			// refer to godoc:
-			//
-			// The [Client.Transport] typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed.
-			// Clients are safe for concurrent use by multiple goroutines.
-			// ==================
-			f.Client.Transport = http.DefaultTransport
-
 			f.Jujutsu(globals.PROXIES[rand.Intn(len(globals.PROXIES))])
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -92,10 +91,6 @@ func main() {
 		Target:      *TARGET,
 		Concurrency: *CONCURRENCY,
 		StopAt:      int(time.Now().Add(time.Second * time.Duration(*DURATION)).Unix()),
-		Client: &http.Client{
-			Jar:     http.DefaultClient.Jar,
-			Timeout: time.Duration(time.Second * 20),
-		},
 		Protocol: *PROXY_TYPE,
 	}
 


### PR DESCRIPTION
**Fixes the following problems:**
- Implemented signal listener to calls like ``CTRL+C`` for gracefully exiting
- Fixed wrong use of ``http.Client``
  > Previous version used same ``http.Client`` in simultaneous threads, and modified the client concurrently which is wrong use-case and not thread-safe.